### PR TITLE
Add frontend services for categories, projects, and sections with com…

### DIFF
--- a/frontend/src/lib/stores/category.ts
+++ b/frontend/src/lib/stores/category.ts
@@ -1,0 +1,292 @@
+import { writable, type Writable } from "svelte/store";
+import { authenticatedFetch } from "./auth";
+import { browser } from "$app/environment";
+import type {
+  Category,
+  CreateCategoryRequest,
+  UpdateCategoryRequest,
+  PaginatedResponse,
+  ApiResponse,
+  Project,
+} from "$lib/types/api";
+
+const API_BASE_URL = browser
+  ? import.meta.env.VITE_API_URL || "http://localhost:8000/api"
+  : "http://localhost:8000/api";
+const CATEGORY_API_URL = `${API_BASE_URL}/categories`;
+
+export interface CategoryState {
+  categories: Category[];
+  loading: boolean;
+  error: string | null;
+  currentCategory: Category | null;
+  projects: Project[];
+}
+
+function createCategoryStore() {
+  const { subscribe, set, update } = writable<CategoryState>({
+    categories: [],
+    loading: false,
+    error: null,
+    currentCategory: null,
+    projects: [],
+  });
+
+  return {
+    subscribe,
+
+    // Get user's own categories (paginated, protected)
+    async getOwn(page = 1, limit = 10): Promise<Category[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${CATEGORY_API_URL}/own?page=${page}&limit=${limit}`
+        );
+        const data: PaginatedResponse<Category> = await response.json();
+
+        if (response.ok) {
+          update((state) => ({
+            ...state,
+            categories: data.data,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error((data as any).error || "Failed to fetch categories");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Get specific category by ID (public)
+    async getById(id: number): Promise<Category> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(`${CATEGORY_API_URL}/id/${id}`);
+        const data: ApiResponse<Category> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            currentCategory: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch category");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+          currentCategory: null,
+        }));
+        throw error;
+      }
+    },
+
+    // Get category by ID (public alternative endpoint)
+    async getPublicById(id: number): Promise<Category> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(`${CATEGORY_API_URL}/public/${id}`);
+        const data: ApiResponse<Category> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            currentCategory: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch category");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+          currentCategory: null,
+        }));
+        throw error;
+      }
+    },
+
+    // Get category's projects (public)
+    async getProjects(id: number): Promise<Project[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(`${CATEGORY_API_URL}/public/${id}/projects`);
+        const data: ApiResponse<Project[]> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            projects: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch category projects");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Create new category (protected)
+    async create(categoryData: CreateCategoryRequest): Promise<Category> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(`${CATEGORY_API_URL}/own`, {
+          method: "POST",
+          body: JSON.stringify(categoryData),
+        });
+        const data: ApiResponse<Category> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            categories: [...state.categories, data.data!],
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to create category");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Update category (protected)
+    async update(id: number, categoryData: UpdateCategoryRequest): Promise<Category> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${CATEGORY_API_URL}/own/${id}`,
+          {
+            method: "PUT",
+            body: JSON.stringify(categoryData),
+          }
+        );
+        const data: ApiResponse<Category> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            categories: state.categories.map((c) =>
+              c.ID === id ? data.data! : c
+            ),
+            currentCategory:
+              state.currentCategory?.ID === id
+                ? data.data!
+                : state.currentCategory,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to update category");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Delete category (protected)
+    async delete(id: number): Promise<void> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${CATEGORY_API_URL}/own/${id}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        if (response.ok) {
+          update((state) => ({
+            ...state,
+            categories: state.categories.filter((c) => c.ID !== id),
+            currentCategory:
+              state.currentCategory?.ID === id ? null : state.currentCategory,
+            loading: false,
+          }));
+        } else {
+          const data = await response.json();
+          throw new Error(data.error || "Failed to delete category");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Clear current category
+    clearCurrent(): void {
+      update((state) => ({
+        ...state,
+        currentCategory: null,
+        projects: [],
+      }));
+    },
+
+    // Clear error
+    clearError(): void {
+      update((state) => ({
+        ...state,
+        error: null,
+      }));
+    },
+  };
+}
+
+export const categoryStore = createCategoryStore();

--- a/frontend/src/lib/stores/index.ts
+++ b/frontend/src/lib/stores/index.ts
@@ -1,0 +1,15 @@
+// Export all stores
+export { auth, getAuthHeaders, authenticatedFetch } from "./auth";
+export type { User, AuthState, AuthStore } from "./auth";
+
+export { portfolioStore } from "./portfolio";
+export type { Portfolio, PortfolioState } from "./portfolio";
+
+export { categoryStore } from "./category";
+export type { CategoryState } from "./category";
+
+export { projectStore } from "./project";
+export type { ProjectState } from "./project";
+
+export { sectionStore } from "./section";
+export type { SectionState } from "./section";

--- a/frontend/src/lib/stores/portfolio.ts
+++ b/frontend/src/lib/stores/portfolio.ts
@@ -135,7 +135,7 @@ function createPortfolioStore() {
 
       try {
         const response = await authenticatedFetch(
-          `${PORTFOLIO_API_URL}/own/id/${id}`,
+          `${PORTFOLIO_API_URL}/own/${id}`,
           {
             method: "PUT",
             body: JSON.stringify(portfolioData),
@@ -172,7 +172,7 @@ function createPortfolioStore() {
 
       try {
         const response = await authenticatedFetch(
-          `${PORTFOLIO_API_URL}/own/id/${id}`,
+          `${PORTFOLIO_API_URL}/own/${id}`,
           {
             method: "DELETE",
           }

--- a/frontend/src/lib/stores/project.ts
+++ b/frontend/src/lib/stores/project.ts
@@ -1,0 +1,320 @@
+import { writable, type Writable } from "svelte/store";
+import { authenticatedFetch } from "./auth";
+import { browser } from "$app/environment";
+import type {
+  Project,
+  CreateProjectRequest,
+  UpdateProjectRequest,
+  PaginatedResponse,
+  ApiResponse,
+} from "$lib/types/api";
+
+const API_BASE_URL = browser
+  ? import.meta.env.VITE_API_URL || "http://localhost:8000/api"
+  : "http://localhost:8000/api";
+const PROJECT_API_URL = `${API_BASE_URL}/projects`;
+
+export interface ProjectState {
+  projects: Project[];
+  loading: boolean;
+  error: string | null;
+  currentProject: Project | null;
+}
+
+function createProjectStore() {
+  const { subscribe, set, update } = writable<ProjectState>({
+    projects: [],
+    loading: false,
+    error: null,
+    currentProject: null,
+  });
+
+  return {
+    subscribe,
+
+    // Get user's own projects (paginated, protected)
+    async getOwn(page = 1, limit = 10): Promise<Project[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${PROJECT_API_URL}/own?page=${page}&limit=${limit}`
+        );
+        const data: PaginatedResponse<Project> = await response.json();
+
+        if (response.ok) {
+          update((state) => ({
+            ...state,
+            projects: data.data,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error((data as any).error || "Failed to fetch projects");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Get specific project by ID (public)
+    async getById(id: number): Promise<Project> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(`${PROJECT_API_URL}/public/${id}`);
+        const data: ApiResponse<Project> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            currentProject: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch project");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+          currentProject: null,
+        }));
+        throw error;
+      }
+    },
+
+    // Get projects by category ID (public)
+    async getByCategory(categoryId: number): Promise<Project[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(`${PROJECT_API_URL}/category/${categoryId}`);
+        const data: ApiResponse<Project[]> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            projects: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch projects by category");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Search projects by skills (public)
+    async searchBySkills(skills: string[]): Promise<Project[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const queryParams = skills.map((skill) => `skills=${encodeURIComponent(skill)}`).join("&");
+        const response = await fetch(`${PROJECT_API_URL}/search/skills?${queryParams}`);
+        const data: ApiResponse<Project[]> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            projects: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to search projects by skills");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Search projects by client (public)
+    async searchByClient(client: string): Promise<Project[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(
+          `${PROJECT_API_URL}/search/client?client=${encodeURIComponent(client)}`
+        );
+        const data: ApiResponse<Project[]> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            projects: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to search projects by client");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Create new project (protected)
+    async create(projectData: CreateProjectRequest): Promise<Project> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(`${PROJECT_API_URL}/own`, {
+          method: "POST",
+          body: JSON.stringify(projectData),
+        });
+        const data: ApiResponse<Project> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            projects: [...state.projects, data.data!],
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to create project");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Update project (protected)
+    async update(id: number, projectData: UpdateProjectRequest): Promise<Project> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${PROJECT_API_URL}/own/${id}`,
+          {
+            method: "PUT",
+            body: JSON.stringify(projectData),
+          }
+        );
+        const data: ApiResponse<Project> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            projects: state.projects.map((p) =>
+              p.ID === id ? data.data! : p
+            ),
+            currentProject:
+              state.currentProject?.ID === id
+                ? data.data!
+                : state.currentProject,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to update project");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Delete project (protected)
+    async delete(id: number): Promise<void> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${PROJECT_API_URL}/own/${id}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        if (response.ok) {
+          update((state) => ({
+            ...state,
+            projects: state.projects.filter((p) => p.ID !== id),
+            currentProject:
+              state.currentProject?.ID === id ? null : state.currentProject,
+            loading: false,
+          }));
+        } else {
+          const data = await response.json();
+          throw new Error(data.error || "Failed to delete project");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Clear current project
+    clearCurrent(): void {
+      update((state) => ({
+        ...state,
+        currentProject: null,
+      }));
+    },
+
+    // Clear error
+    clearError(): void {
+      update((state) => ({
+        ...state,
+        error: null,
+      }));
+    },
+  };
+}
+
+export const projectStore = createProjectStore();

--- a/frontend/src/lib/stores/section.ts
+++ b/frontend/src/lib/stores/section.ts
@@ -1,0 +1,289 @@
+import { writable, type Writable } from "svelte/store";
+import { authenticatedFetch } from "./auth";
+import { browser } from "$app/environment";
+import type {
+  Section,
+  CreateSectionRequest,
+  UpdateSectionRequest,
+  PaginatedResponse,
+  ApiResponse,
+} from "$lib/types/api";
+
+const API_BASE_URL = browser
+  ? import.meta.env.VITE_API_URL || "http://localhost:8000/api"
+  : "http://localhost:8000/api";
+const SECTION_API_URL = `${API_BASE_URL}/sections`;
+
+export interface SectionState {
+  sections: Section[];
+  loading: boolean;
+  error: string | null;
+  currentSection: Section | null;
+}
+
+function createSectionStore() {
+  const { subscribe, set, update } = writable<SectionState>({
+    sections: [],
+    loading: false,
+    error: null,
+    currentSection: null,
+  });
+
+  return {
+    subscribe,
+
+    // Get user's own sections (paginated, protected)
+    async getOwn(page = 1, limit = 10): Promise<Section[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${SECTION_API_URL}/own?page=${page}&limit=${limit}`
+        );
+        const data: PaginatedResponse<Section> = await response.json();
+
+        if (response.ok) {
+          update((state) => ({
+            ...state,
+            sections: data.data,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error((data as any).error || "Failed to fetch sections");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Get specific section by ID (public)
+    async getById(id: number): Promise<Section> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(`${SECTION_API_URL}/public/${id}`);
+        const data: ApiResponse<Section> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            currentSection: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch section");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+          currentSection: null,
+        }));
+        throw error;
+      }
+    },
+
+    // Get sections by portfolio ID (public)
+    async getByPortfolio(portfolioId: number): Promise<Section[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(`${SECTION_API_URL}/portfolio/${portfolioId}`);
+        const data: ApiResponse<Section[]> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            sections: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch sections by portfolio");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Get sections by type (public)
+    async getByType(type: string): Promise<Section[]> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await fetch(
+          `${SECTION_API_URL}/type?type=${encodeURIComponent(type)}`
+        );
+        const data: ApiResponse<Section[]> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            sections: data.data!,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to fetch sections by type");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Create new section (protected)
+    async create(sectionData: CreateSectionRequest): Promise<Section> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(`${SECTION_API_URL}/own`, {
+          method: "POST",
+          body: JSON.stringify(sectionData),
+        });
+        const data: ApiResponse<Section> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            sections: [...state.sections, data.data!],
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to create section");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Update section (protected)
+    async update(id: number, sectionData: UpdateSectionRequest): Promise<Section> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${SECTION_API_URL}/own/${id}`,
+          {
+            method: "PUT",
+            body: JSON.stringify(sectionData),
+          }
+        );
+        const data: ApiResponse<Section> = await response.json();
+
+        if (response.ok && data.data) {
+          update((state) => ({
+            ...state,
+            sections: state.sections.map((s) =>
+              s.ID === id ? data.data! : s
+            ),
+            currentSection:
+              state.currentSection?.ID === id
+                ? data.data!
+                : state.currentSection,
+            loading: false,
+          }));
+          return data.data;
+        } else {
+          throw new Error(data.error || "Failed to update section");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Delete section (protected)
+    async delete(id: number): Promise<void> {
+      update((state) => ({ ...state, loading: true, error: null }));
+
+      try {
+        const response = await authenticatedFetch(
+          `${SECTION_API_URL}/own/${id}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        if (response.ok) {
+          update((state) => ({
+            ...state,
+            sections: state.sections.filter((s) => s.ID !== id),
+            currentSection:
+              state.currentSection?.ID === id ? null : state.currentSection,
+            loading: false,
+          }));
+        } else {
+          const data = await response.json();
+          throw new Error(data.error || "Failed to delete section");
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        update((state) => ({
+          ...state,
+          loading: false,
+          error: errorMessage,
+        }));
+        throw error;
+      }
+    },
+
+    // Clear current section
+    clearCurrent(): void {
+      update((state) => ({
+        ...state,
+        currentSection: null,
+      }));
+    },
+
+    // Clear error
+    clearError(): void {
+      update((state) => ({
+        ...state,
+        error: null,
+      }));
+    },
+  };
+}
+
+export const sectionStore = createSectionStore();

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -1,0 +1,140 @@
+// API Response Types
+export interface ApiResponse<T = any> {
+  message?: string;
+  data?: T;
+  error?: string;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  page: number;
+  limit: number;
+  message?: string;
+}
+
+// Portfolio Types
+export interface Portfolio {
+  ID: number;
+  title: string;
+  description?: string | null;
+  owner_id: string;
+  CreatedAt: string;
+  UpdatedAt: string;
+  categories?: Category[];
+  sections?: Section[];
+}
+
+export interface CreatePortfolioRequest {
+  title: string;
+  description?: string;
+}
+
+export interface UpdatePortfolioRequest {
+  title?: string;
+  description?: string;
+}
+
+// Category Types
+export interface Category {
+  ID: number;
+  title: string;
+  description?: string | null;
+  position: number;
+  portfolio_id: number;
+  owner_id: string;
+  CreatedAt: string;
+  UpdatedAt: string;
+  projects?: Project[];
+}
+
+export interface CreateCategoryRequest {
+  title: string;
+  description?: string;
+  portfolio_id: number;
+}
+
+export interface UpdateCategoryRequest {
+  title?: string;
+  description?: string;
+}
+
+// Project Types
+export interface Project {
+  ID: number;
+  title: string;
+  images?: string[];
+  main_image?: string;
+  description: string;
+  skills?: string[];
+  client?: string;
+  link?: string;
+  position: number;
+  category_id: number;
+  owner_id: string;
+  CreatedAt: string;
+  UpdatedAt: string;
+}
+
+export interface CreateProjectRequest {
+  title: string;
+  images?: string[];
+  main_image?: string;
+  description: string;
+  skills?: string[];
+  client?: string;
+  link?: string;
+  category_id: number;
+}
+
+export interface UpdateProjectRequest {
+  title?: string;
+  images?: string[];
+  main_image?: string;
+  description?: string;
+  skills?: string[];
+  client?: string;
+  link?: string;
+}
+
+// Section Types
+export interface Section {
+  ID: number;
+  title: string;
+  description?: string | null;
+  type: string;
+  position: number;
+  portfolio_id: number;
+  owner_id: string;
+  CreatedAt: string;
+  UpdatedAt: string;
+}
+
+export interface CreateSectionRequest {
+  title: string;
+  description?: string;
+  type: string;
+  portfolio_id: number;
+}
+
+export interface UpdateSectionRequest {
+  title?: string;
+  description?: string;
+  type?: string;
+}
+
+// Pagination Parameters
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+}
+
+// Search Parameters
+export interface ProjectSearchParams {
+  skills?: string[];
+  client?: string;
+}
+
+export interface SectionFilterParams {
+  type?: string;
+  portfolio_id?: number;
+}

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1,0 +1,31 @@
+// Export all API types
+export type {
+  // Response types
+  ApiResponse,
+  PaginatedResponse,
+
+  // Portfolio types
+  Portfolio,
+  CreatePortfolioRequest,
+  UpdatePortfolioRequest,
+
+  // Category types
+  Category,
+  CreateCategoryRequest,
+  UpdateCategoryRequest,
+
+  // Project types
+  Project,
+  CreateProjectRequest,
+  UpdateProjectRequest,
+
+  // Section types
+  Section,
+  CreateSectionRequest,
+  UpdateSectionRequest,
+
+  // Utility types
+  PaginationParams,
+  ProjectSearchParams,
+  SectionFilterParams,
+} from "./api";


### PR DESCRIPTION
…plete CRUD operations

Create comprehensive TypeScript services to consume backend API endpoints:
- Add API types file with interfaces matching backend DTOs for all resources
- Create category service with CRUD operations and public endpoints (getById, getProjects)
- Create project service with CRUD, search by skills/client, and category filtering
- Create section service with CRUD and filtering by type/portfolio
- Fix portfolio service endpoints (remove incorrect /id/ path segment)
- Add index files for easier imports of stores and types
- All services follow consistent patterns with loading states, error handling, and TypeScript types

Services support both authenticated (own) and public endpoints with proper authentication headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)