### PR TITLE
fix(dockerfile): updated go version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM docker.io/golang:1.23-alpine AS builder
+FROM docker.io/golang:1.24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## What does this PR do?
Updates go version of go version in docker image.

## Why are these changes needed?
It was impossible to run docker-compose up out of the box following README.md

## How has this been tested?
- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing

## Related Issues
Closes #5


## Checklist
- [X] Code follows style guidelines
- [ ] Tests added/updated
- [ ] Documentation updated
- [X] No breaking changes
- [X] Reviewed my own code